### PR TITLE
fix: Do not use the official microsoft bullet3 port-version

### DIFF
--- a/cmake/ports/bullet3/vcpkg.json
+++ b/cmake/ports/bullet3/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "bullet3",
   "version": "3.25",
-  "port-version": 3,
+  "port-version": 33,
   "description": "Bullet Physics is a professional collision detection, rigid body, and soft body dynamics library",
   "homepage": "https://github.com/bulletphysics/bullet3",
   "license": "Zlib",


### PR DESCRIPTION
This will potentially load an unpatched version of Bullet3, which we don't want. By setting it to 33, it insures that we use our custom patched bullet. 

Setting it to 4 could lead to problems in the future if the official microsoft port version is also incremented. So 33 avoids that

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Bullet3 physics library version in build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->